### PR TITLE
feat:支持输入框与订阅按键强制多行显示

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@
 
 <!-- 同时设置对齐方式和标题 -->
 <follow-card text-align="left" title-text="加入我的订阅列表"></follow-card>
+
+<!-- 输入框与订阅按键强制多行显示 -->
+<follow-card show-multiline="true"></follow-card>
 ```
 
 ## 预览

--- a/packages/follow-card/src/follow-card.ts
+++ b/packages/follow-card/src/follow-card.ts
@@ -77,7 +77,7 @@ export class FollowCard extends LitElement {
                           <h1 class="text-xl sm:text-2xl font-semibold text-title mb-2">${this.titleText}</h1>
                       </div>
                       ` : ''}
-                      <div class="flex flex-col gap-4 ${this.showMultiLine != 'true' && 'sm:flex-row'}">
+                      <div class="flex flex-col gap-4 ${this.showMultiLine !== 'true' && 'sm:flex-row'}">
                           <div class="input-wrapper flex-1">
                               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="text-description">
                                   <path d="M1.5 8.67v8.58a3 3 0 003 3h15a3 3 0 003-3V8.67l-8.928 5.493a3 3 0 01-3.144 0L1.5 8.67z" />

--- a/packages/follow-card/src/follow-card.ts
+++ b/packages/follow-card/src/follow-card.ts
@@ -11,6 +11,9 @@ export class FollowCard extends LitElement {
   @property({ type: String, attribute: 'show-title' })
   showTitle = 'true';
 
+  @property({ type: String, attribute: 'show-multiline' })
+  showMultiLine = "false";
+
   @property({ type: String, attribute: 'title-text' })
   titleText = '订阅最新内容推送';
 
@@ -74,7 +77,7 @@ export class FollowCard extends LitElement {
                           <h1 class="text-xl sm:text-2xl font-semibold text-title mb-2">${this.titleText}</h1>
                       </div>
                       ` : ''}
-                      <div class="flex flex-col sm:flex-row gap-4">
+                      <div class="flex flex-col gap-4 ${this.showMultiLine != 'true' && 'sm:flex-row'}">
                           <div class="input-wrapper flex-1">
                               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="text-description">
                                   <path d="M1.5 8.67v8.58a3 3 0 003 3h15a3 3 0 003-3V8.67l-8.928 5.493a3 3 0 01-3.144 0L1.5 8.67z" />

--- a/ui/src/editor/FollowCardView.vue
+++ b/ui/src/editor/FollowCardView.vue
@@ -26,6 +26,9 @@ const titleText = computed({
     props.updateAttributes({ titleText: titleText });
   },
 });
+const showMultiline = computed(() => {
+  return props.node.attrs.showMultiline;
+});
 </script>
 
 <template>
@@ -39,6 +42,7 @@ const titleText = computed({
         :text-align="textAlign"
         :show-title="showTitle"
         :title-text="titleText" 
+        :show-multiline="showMultiline"
       />
     </div>
     

--- a/ui/src/editor/follow-card-edited.ts
+++ b/ui/src/editor/follow-card-edited.ts
@@ -22,6 +22,8 @@ import BubbleItemICardTitle from "@/editor/BubbleItemICardTitle.vue";
 import FluentAppTitle20Regular from '~icons/fluent/app-title-20-regular?width=1.2em&height=1.2em';
 import FluentAppTitle20Filled from '~icons/fluent/app-title-20-filled?width=1.2em&height=1.2em';
 import MdiFormatTitle from '~icons/mdi/format-title?width=1.2em&height=1.2em';
+import LsiconDensityLFilled from '~icons/lsicon/density-l-filled';
+import LsiconDensityLOutline from '~icons/lsicon/density-l-outline';
 
 declare module "@halo-dev/richtext-editor" {
   interface Commands<ReturnType> {
@@ -72,6 +74,17 @@ const FollowCardExtension = Node.create({
         renderHTML: (attributes) => {
           return {
             "title-text": attributes.titleText,
+          };
+        },
+      },
+      showMultiline: {
+        default: "false",
+        parseHTML: (element) => {
+          return element.getAttribute("show-multiline");
+        },
+        renderHTML: (attributes) => {
+          return {
+            "show-multiline": attributes.showMultiline,
           };
         },
       },
@@ -220,6 +233,29 @@ const FollowCardExtension = Node.create({
                 title: "修改标题",
                 action: () => {
                   return markRaw(BubbleItemICardTitle);
+                },
+              },
+            },
+            {
+              priority: 47,
+              props: {
+                title:
+                  editor.getAttributes(FollowCardExtension.name).showMultiline === "true"
+                    ? "多行显示"
+                    : "默认显示",
+                isActive: () => {
+                  return editor.getAttributes(FollowCardExtension.name).showMultiline  === "true";
+                },
+                icon: markRaw(
+                  editor.getAttributes(FollowCardExtension.name).showMultiline === "true"
+                    ? LsiconDensityLFilled
+                    : LsiconDensityLOutline
+                ),
+                action: () => {
+                  const showMultiline = editor.getAttributes(FollowCardExtension.name).showMultiline;
+                  editor.commands.updateAttributes(FollowCardExtension.name, {
+                    showMultiline: showMultiline === "false" ? "true" : "false"
+                  });
                 },
               },
             },


### PR DESCRIPTION
增加属性：`show-multiline`，默认：输入框与订阅按键在宽布局下单行显示，窄布局下多行显示，设置属性后将会强制多行显示。

使用下面的代码可以在狭窄空间下显示，例如侧边栏中显示。

feat: #5 

``` html
<follow-card class="sidebar-subscription" show-multiline="true" text-align="center"></follow-card>
<style>
  .sidebar-subscription {
  /* 卡片内边距 */
  --follow-card-padding-sm: 1.2rem;  /* 小屏幕内边距 */
  --follow-card-padding-md: 1.2rem;    /* 中屏幕内边距 */
  --follow-card-padding-lg: 1.2rem;    /* 大屏幕内边距 */
  }
</style>
```